### PR TITLE
fix missing 'last seen' dates

### DIFF
--- a/src/Twig/Extension/AuthExtension.php
+++ b/src/Twig/Extension/AuthExtension.php
@@ -33,6 +33,7 @@ class AuthExtension extends Extension
             new SimpleFunction('auth_oauth',                  [AuthRuntime::class, 'getAuthOauth'],  $safe),
             new SimpleFunction('auth_has_role',               [AuthRuntime::class, 'hasRole'],         $safe),
             new SimpleFunction('auth_providers',              [AuthRuntime::class, 'getProviders'],    $safe),
+            new SimpleFunction('auth_providers_dates',        [AuthRuntime::class, 'getProvidersDates'],    $safe),
             new SimpleFunction('auth_auth_switcher',         [AuthRuntime::class, 'renderSwitcher'],  $safe + $env),
             new SimpleFunction('auth_auth_associate',        [AuthRuntime::class, 'renderAssociate'], $safe + $env),
             new SimpleFunction('auth_auth_login',            [AuthRuntime::class, 'renderLogin'],     $safe + $env),

--- a/src/Twig/Extension/AuthExtension.php
+++ b/src/Twig/Extension/AuthExtension.php
@@ -33,7 +33,7 @@ class AuthExtension extends Extension
             new SimpleFunction('auth_oauth',                  [AuthRuntime::class, 'getAuthOauth'],  $safe),
             new SimpleFunction('auth_has_role',               [AuthRuntime::class, 'hasRole'],         $safe),
             new SimpleFunction('auth_providers',              [AuthRuntime::class, 'getProviders'],    $safe),
-            new SimpleFunction('auth_providers_dates',        [AuthRuntime::class, 'getProvidersDates'],    $safe),
+            new SimpleFunction('auth_lastseen',               [AuthRuntime::class, 'getProvidersLastSeen'],    $safe),
             new SimpleFunction('auth_auth_switcher',         [AuthRuntime::class, 'renderSwitcher'],  $safe + $env),
             new SimpleFunction('auth_auth_associate',        [AuthRuntime::class, 'renderAssociate'], $safe + $env),
             new SimpleFunction('auth_auth_login',            [AuthRuntime::class, 'renderLogin'],     $safe + $env),

--- a/src/Twig/Extension/AuthExtension.php
+++ b/src/Twig/Extension/AuthExtension.php
@@ -27,13 +27,13 @@ class AuthExtension extends Extension
         $env  = ['needs_environment' => true];
 
         return [
-            new SimpleFunction('is_auth',                     [AuthRuntime::class, 'isAuth'],        $safe),
-            new SimpleFunction('auth',                        [AuthRuntime::class, 'getAuth'],       $safe),
-            new SimpleFunction('auth_meta',                   [AuthRuntime::class, 'getAuthMeta'],   $safe),
-            new SimpleFunction('auth_oauth',                  [AuthRuntime::class, 'getAuthOauth'],  $safe),
-            new SimpleFunction('auth_has_role',               [AuthRuntime::class, 'hasRole'],         $safe),
-            new SimpleFunction('auth_providers',              [AuthRuntime::class, 'getProviders'],    $safe),
-            new SimpleFunction('auth_lastseen',               [AuthRuntime::class, 'getProvidersLastSeen'],    $safe),
+            new SimpleFunction('is_auth',                    [AuthRuntime::class, 'isAuth'],          $safe),
+            new SimpleFunction('auth',                       [AuthRuntime::class, 'getAuth'],         $safe),
+            new SimpleFunction('auth_meta',                  [AuthRuntime::class, 'getAuthMeta'],     $safe),
+            new SimpleFunction('auth_oauth',                 [AuthRuntime::class, 'getAuthOauth'],    $safe),
+            new SimpleFunction('auth_has_role',              [AuthRuntime::class, 'hasRole'],         $safe),
+            new SimpleFunction('auth_providers',             [AuthRuntime::class, 'getProviders'],    $safe),
+            new SimpleFunction('auth_lastseen',              [AuthRuntime::class, 'getProvidersLastSeen'],    $safe),
             new SimpleFunction('auth_auth_switcher',         [AuthRuntime::class, 'renderSwitcher'],  $safe + $env),
             new SimpleFunction('auth_auth_associate',        [AuthRuntime::class, 'renderAssociate'], $safe + $env),
             new SimpleFunction('auth_auth_login',            [AuthRuntime::class, 'renderLogin'],     $safe + $env),

--- a/src/Twig/Extension/AuthRuntime.php
+++ b/src/Twig/Extension/AuthRuntime.php
@@ -195,23 +195,22 @@ class AuthRuntime extends TwigExtension
      *
      * @param string $guid
      *
-     * @return array
+     * @return \DateTime
      */
     public function getProvidersLastSeen($guid = null)
     {
-        $providers = [];
         if ($guid === null) {
             $auth = $this->session->getAuthorisation();
 
             if ($auth === null) {
-                return $providers;
+                return null;
             }
             $guid = $auth->getGuid();
         }
 
         $providerEntities = $this->records->getProvisionsByGuid($guid);
         if ($providerEntities === false) {
-            return $providers;
+            return null;
         }
 
         /** @var Storage\Entity\Provider $providerEntity */
@@ -225,7 +224,7 @@ class AuthRuntime extends TwigExtension
                 $lastseen = $provider['lastseen'];
             }
             if ($lastupdate <= $provider['lastupdate']) {
-              $lastupdate = $provider['lastupdate'];
+                $lastupdate = $provider['lastupdate'];
             }
         }
         // make an empty last seen date the same as the last update date

--- a/src/Twig/Extension/AuthRuntime.php
+++ b/src/Twig/Extension/AuthRuntime.php
@@ -192,7 +192,7 @@ class AuthRuntime extends TwigExtension
 
     /**
      * Return an array of registered OAuth providers for an account with
-     * lst steen and last updated dates
+     * last seen and last updated dates.
      *
      * @param string $guid
      *
@@ -205,7 +205,7 @@ class AuthRuntime extends TwigExtension
             $auth = $this->session->getAuthorisation();
 
             if ($auth === null) {
-              return $providers;
+                return $providers;
             }
             $guid = $auth->getGuid();
         }
@@ -219,20 +219,21 @@ class AuthRuntime extends TwigExtension
         $providers['lastseen'] = null;
         $providers['lastupdate'] = null;
         foreach ($providerEntities as $providerEntity) {
-            $provider['name'] = $providerEntity->getProvider();
-            $provider['lastseen'] = $providerEntity->getLastSeen();
+            $provider['name']       = $providerEntity->getProvider();
+            $provider['lastseen']   = $providerEntity->getLastSeen();
             $provider['lastupdate'] = $providerEntity->getLastUpdate();
 
             $providers[] = $provider;
-            if($providers['lastseen'] <= $provider['lastseen']) {
-              $providers['lastseen'] = $provider['lastseen'];
+            if ($providers['lastseen'] <= $provider['lastseen']) {
+                 $providers['lastseen'] = $provider['lastseen'];
             }
-            if($providers['lastupdate'] <= $provider['lastupdate']) {
-              $providers['lastupdate'] = $provider['lastupdate'];
+            if ($providers['lastupdate'] <= $provider['lastupdate']) {
+                $providers['lastupdate'] = $provider['lastupdate'];
             }
         }
-        if($providers['lastseen'] <= $provider['lastupdate']) {
-          $providers['lastseen'] = $provider['lastupdate'];
+        // make an empty last seen date the same as the last update date
+        if (empty($providers['lastseen']) && !empty($provider['lastupdate'])) {
+            $providers['lastseen'] = $provider['lastupdate'];
         }
 
         return $providers;

--- a/src/Twig/Extension/AuthRuntime.php
+++ b/src/Twig/Extension/AuthRuntime.php
@@ -191,14 +191,13 @@ class AuthRuntime extends TwigExtension
     }
 
     /**
-     * Return an array of registered OAuth providers for an account with
-     * last seen and last updated dates.
+     * Return last seen date from all OAuth providers for an account
      *
      * @param string $guid
      *
      * @return array
      */
-    public function getProvidersDates($guid = null)
+    public function getProvidersLastSeen($guid = null)
     {
         $providers = [];
         if ($guid === null) {
@@ -216,25 +215,25 @@ class AuthRuntime extends TwigExtension
         }
 
         /** @var Storage\Entity\Provider $providerEntity */
-        $providers['lastseen'] = null;
-        $providers['lastupdate'] = null;
+        $lastseen = null;
+        $lastupdate = null;
         foreach ($providerEntities as $providerEntity) {
             $provider['lastseen']   = $providerEntity->getLastSeen();
             $provider['lastupdate'] = $providerEntity->getLastUpdate();
 
-            if ($providers['lastseen'] <= $provider['lastseen']) {
-                 $providers['lastseen'] = $provider['lastseen'];
+            if ($lastseen <= $provider['lastseen']) {
+                $lastseen = $provider['lastseen'];
             }
-            if ($providers['lastupdate'] <= $provider['lastupdate']) {
-                $providers['lastupdate'] = $provider['lastupdate'];
+            if ($lastupdate <= $provider['lastupdate']) {
+              $lastupdate = $provider['lastupdate'];
             }
         }
         // make an empty last seen date the same as the last update date
-        if (empty($providers['lastseen']) && !empty($provider['lastupdate'])) {
-            $providers['lastseen'] = $provider['lastupdate'];
+        if (empty($lastseen) && !empty($lastupdate)) {
+            $lastseen = $lastupdate;
         }
 
-        return $providers;
+        return $lastseen;
     }
 
     /**

--- a/src/Twig/Extension/AuthRuntime.php
+++ b/src/Twig/Extension/AuthRuntime.php
@@ -191,6 +191,54 @@ class AuthRuntime extends TwigExtension
     }
 
     /**
+     * Return an array of registered OAuth providers for an account with
+     * lst steen and last updated dates
+     *
+     * @param string $guid
+     *
+     * @return array
+     */
+    public function getProvidersDates($guid = null)
+    {
+        $providers = [];
+        if ($guid === null) {
+            $auth = $this->session->getAuthorisation();
+
+            if ($auth === null) {
+              return $providers;
+            }
+            $guid = $auth->getGuid();
+        }
+
+        $providerEntities = $this->records->getProvisionsByGuid($guid);
+        if ($providerEntities === false) {
+            return $providers;
+        }
+
+        /** @var Storage\Entity\Provider $providerEntity */
+        $providers['lastseen'] = null;
+        $providers['lastupdate'] = null;
+        foreach ($providerEntities as $providerEntity) {
+            $provider['name'] = $providerEntity->getProvider();
+            $provider['lastseen'] = $providerEntity->getLastSeen();
+            $provider['lastupdate'] = $providerEntity->getLastUpdate();
+
+            $providers[] = $provider;
+            if($providers['lastseen'] <= $provider['lastseen']) {
+              $providers['lastseen'] = $provider['lastseen'];
+            }
+            if($providers['lastupdate'] <= $provider['lastupdate']) {
+              $providers['lastupdate'] = $provider['lastupdate'];
+            }
+        }
+        if($providers['lastseen'] <= $provider['lastupdate']) {
+          $providers['lastseen'] = $provider['lastupdate'];
+        }
+
+        return $providers;
+    }
+
+    /**
      * Display login/logout button(s) depending on status.
      *
      * @param TwigEnvironment $twigEnvironment

--- a/src/Twig/Extension/AuthRuntime.php
+++ b/src/Twig/Extension/AuthRuntime.php
@@ -219,11 +219,9 @@ class AuthRuntime extends TwigExtension
         $providers['lastseen'] = null;
         $providers['lastupdate'] = null;
         foreach ($providerEntities as $providerEntity) {
-            $provider['name']       = $providerEntity->getProvider();
             $provider['lastseen']   = $providerEntity->getLastSeen();
             $provider['lastupdate'] = $providerEntity->getLastUpdate();
 
-            $providers[] = $provider;
             if ($providers['lastseen'] <= $provider['lastseen']) {
                  $providers['lastseen'] = $provider['lastseen'];
             }

--- a/templates/admin/auth.twig
+++ b/templates/admin/auth.twig
@@ -69,7 +69,7 @@
                         </thead>
                         <tbody class="auth-list-items">
                         {% for auth in auth %}
-                            {% set auth_providers = auth_providers_dates(auth.guid) %}
+                            {% set lastseen = auth_lastseen(auth.guid) %}
 
                             {% if auth.enabled %}{% set enabled = '' %}{% else %}{% set enabled = 'strikeout' %}{% endif %}
                             <tr class="{{ enabled }}" id="auth-auth[{{ auth.guid }}]">
@@ -89,7 +89,7 @@
                                     {% endfor %}
                                 </td>
                                 <td class="auth-lastseen">
-                                    <time class="buic-moment" data-bolt-widget="buicMoment" datetime="{{ auth_providers.lastseen }}">{{ auth_providers.lastseen }}</time>
+                                    <time class="buic-moment" data-bolt-widget="buicMoment" datetime="{{ lastseen }}">{{ lastseen }}</time>
                                 </td>
                                 <td class="auth-guid">
                                     {% spaceless %}

--- a/templates/admin/auth.twig
+++ b/templates/admin/auth.twig
@@ -69,6 +69,8 @@
                         </thead>
                         <tbody class="auth-list-items">
                         {% for auth in auth %}
+                            {% set auth_providers = auth_providers_dates(auth.guid) %}
+
                             {% if auth.enabled %}{% set enabled = '' %}{% else %}{% set enabled = 'strikeout' %}{% endif %}
                             <tr class="{{ enabled }}" id="auth-auth[{{ auth.guid }}]">
                                 <td class="auth-cb">
@@ -87,7 +89,7 @@
                                     {% endfor %}
                                 </td>
                                 <td class="auth-lastseen">
-                                    <time class="buic-moment" data-bolt-widget="buicMoment" datetime="{{ auth.lastseen }}">{{ auth.lastseen }}</time>
+                                    <time class="buic-moment" data-bolt-widget="buicMoment" datetime="{{ auth_providers.lastseen }}">{{ auth_providers.lastseen }}</time>
                                 </td>
                                 <td class="auth-guid">
                                     {% spaceless %}


### PR DESCRIPTION
This adds a new method that is exposed by twig getProvidersDates to enable viewing of last seen in backend.

It's a bit hackish, and can probably be done cleaner.. but it works at the moment.