### PR TITLE
Remove all references to "bio"

### DIFF
--- a/lib/League/OAuth2/Client/Provider/Facebook.php
+++ b/lib/League/OAuth2/Client/Provider/Facebook.php
@@ -107,9 +107,9 @@ class Facebook extends AbstractProvider
         ];
 
         // backwards compatibility less than 2.8
-        if ((float) substr($this->graphApiVersion, 1) < 2.8) {
-            $fields[] = 'bio';
-        }
+        // if ((float) substr($this->graphApiVersion, 1) < 2.8) {
+        //     $fields[] = 'bio';
+        // }
 
         $appSecretProof = AppSecretProof::create($this->clientSecret, $token->getToken());
 


### PR DESCRIPTION
Fixes error "Bio field is deprecated for versions v2.8 and higher"