### PR TITLE
Continuation of admin UI tweaks

### DIFF
--- a/templates/admin/profile_edit.twig
+++ b/templates/admin/profile_edit.twig
@@ -18,14 +18,16 @@
 {% block page_main %}
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <div class="row">
-        <h4>Edit Existing Profile</h4>
+        <div class="col-xs-12">
+            <h4>{{ __('Editing Existing Profile') }}</h4>
+        </div>
     </div>
 
     <div class="row profile">
 
         <div class="col-md-9">
             {% block profile %}
-                {{ form_start(form_profile_edit, {'attr': {'id': 'profile', 'class': 'row form-horizontal'}, 'action': null}) }}
+                {{ form_start(form_profile_edit, {'attr': {'id': 'profile', 'class': 'form-horizontal'}, 'action': null}) }}
                 <div class="form-group">
                     {{ form_label(form_profile_edit.displayname, null, {'label_attr': {'class': 'main col-sm-2 control-label'}}) }}
                     {{ form_errors(form_profile_edit.displayname) }}

--- a/templates/admin/profile_edit.twig
+++ b/templates/admin/profile_edit.twig
@@ -25,35 +25,34 @@
 
         <div class="col-md-9">
             {% block profile %}
-                {{ form_start(form_profile_edit, {'attr': {'id': 'profile', 'class': 'row'}, 'action': null}) }}
-                
+                {{ form_start(form_profile_edit, {'attr': {'id': 'profile', 'class': 'row form-horizontal'}, 'action': null}) }}
                 <div class="form-group">
-                    {{ form_label(form_profile_edit.displayname, null, {'label_attr': {'class': 'main control-label'}}) }}
+                    {{ form_label(form_profile_edit.displayname, null, {'label_attr': {'class': 'main col-sm-2 control-label'}}) }}
                     {{ form_errors(form_profile_edit.displayname) }}
-                    {{ form_widget(form_profile_edit.displayname, { 'attr': {'class': 'form-control large'} }) }}
+                    {{ form_widget(form_profile_edit.displayname, { 'attr': {'class': 'form-control large col-sm-10 col-md-6 col-lg-4'} }) }}
                 </div>
                 <div class="form-group">
-                    {{ form_label(form_profile_edit.email, null, {'label_attr': {'class': 'main control-label'}}) }}
+                    {{ form_label(form_profile_edit.email, null, {'label_attr': {'class': 'main col-sm-2 control-label'}}) }}
                     {{ form_errors(form_profile_edit.displayname) }}
-                    {{ form_widget(form_profile_edit.email, { 'attr': {'class': 'form-control large'} }) }}
+                    {{ form_widget(form_profile_edit.email, { 'attr': {'class': 'form-control large col-sm-10 col-md-6 col-lg-4'} }) }}
                 </div>
                 <div class="form-group">
-                    {{ form_label(form_profile_edit.password.first, null, {'label_attr': {'class': 'main control-label'}}) }}
+                    {{ form_label(form_profile_edit.password.first, null, {'label_attr': {'class': 'main col-sm-2 control-label'}}) }}
                     {{ form_errors(form_profile_edit.password.first) }}
-                    {{ form_widget(form_profile_edit.password.first, { 'attr': {'class': 'form-control large', 'autocomplete': 'new-password'}, 'required': false }) }}
+                    {{ form_widget(form_profile_edit.password.first, { 'attr': {'class': 'form-control large col-sm-10 col-md-6 col-lg-4', 'autocomplete': 'new-password'}, 'required': false }) }}
                 </div>
                 <div class="form-group">
-                    {{ form_label(form_profile_edit.password.second, null, {'label_attr': {'class': 'main control-label'}}) }}
+                    {{ form_label(form_profile_edit.password.second, null, {'label_attr': {'class': 'main col-sm-2 control-label'}}) }}
                     {{ form_errors(form_profile_edit.password.second) }}
-                    {{ form_widget(form_profile_edit.password.second, { 'attr': {'class': 'form-control large', 'autocomplete': 'new-password'}, 'required': false }) }}
+                    {{ form_widget(form_profile_edit.password.second, { 'attr': {'class': 'form-control large col-sm-10 col-md-6 col-lg-4', 'autocomplete': 'new-password'}, 'required': false }) }}
                 </div>
-                
+
                 {% include '@AuthAdmin/profile_edit_meta.twig' ignore missing %}
 
                 <br>
-            <div class="hidden">
-                {{ form_row(form_profile_edit.submit) }}
-            </div>
+                <div class="hidden">
+                    {{ form_row(form_profile_edit.submit) }}
+                </div>
                 {{ form_end(form_profile_edit) }}
             {% endblock profile %}
         </div>

--- a/templates/admin/profile_edit_meta.twig
+++ b/templates/admin/profile_edit_meta.twig
@@ -1,0 +1,19 @@
+{% for element in form_profile_edit %}
+    {% if not element.rendered and element.vars.name not in ['submit', '_token'] %}
+        {% set fieldtype = element.vars.block_prefixes[1] %}
+        {% if fieldtype in ['datetime'] %}
+            <div class="form-group">
+                {{ form_label(element, null, {'label_attr': {'class': 'main col-sm-2 control-label'}}) }}
+                {{ form_errors(element) }}
+                {{ form_widget(element.date, {'attr': {'class': 'col-sm-3 form-group'}}) }}
+                {{ form_widget(element.time, {'attr': {'class': 'col-sm-3'}}) }}
+            </div>
+        {% else %}
+            <div class="form-group">
+                {{ form_label(element, null, {'label_attr': {'class': 'main col-sm-2 control-label'}}) }}
+                {{ form_errors(element) }}
+                {{ form_widget(element, { 'attr': {'class': 'form-control large col-sm-10 col-md-6 col-lg-4'}, 'required': false }) }}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
There's nothing too major here, just an attempt to make the Auth user edit match Bolt's normal user edit page as closely as possible.

Also implemented some improvements for meta field handling. Eventually it would be nice to get all these to render using the same templates as the editcontent fields use, but there's still some inconsistencies in data between Symfony forms which is used here in Bolt Auth.

For now I've just added a fix for datetime fields which rendered pretty horribly in the backend UI, as I spot any other problem field types I'll PR separately.