### PR TITLE
Fix auth.session service declaration.

### DIFF
--- a/src/Provider/AuthServiceProvider.php
+++ b/src/Provider/AuthServiceProvider.php
@@ -181,7 +181,7 @@ class AuthServiceProvider implements ServiceProviderInterface, EventSubscriberIn
 
         $app['auth.session'] = $app->share(
             function ($app) {
-                return new AccessControl\Session($app['auth.records'], $app['session'], $app['url_generator']->generate('homepage'));
+                return new AccessControl\Session($app['auth.records'], $app['session'], $app['url_generator']);
             }
         );
 


### PR DESCRIPTION
The service `auth.session` calls `url_generator` during its construction. This throws an exception when injecting `auth.session` in a service used during the bootstrap phase (an EventListener for example).

This commit injects the full `url_generator` service rather than calling it during the construction. `url_generator` is then called internally in `auth.session` service.