### PR TITLE
set the password when adding new user in backend

### DIFF
--- a/src/Controller/Backend.php
+++ b/src/Controller/Backend.php
@@ -270,6 +270,7 @@ class Backend extends AbstractController
             $oauth = new Storage\Entity\Oauth();
             $oauth->setGuid($account->getGuid());
             $oauth->setResourceOwnerId($account->getGuid());
+            $oauth->setPassword($entity->getPassword());
             $oauth->setEnabled(true);
             $app['auth.records']->saveOauth($oauth);
 


### PR DESCRIPTION
the password isn't set when creating a new user in the backend (/bolt/extensions/auth/add)

credit to: @Epoxyde - https://github.com/BoltAuth/Auth/issues/35