### PR TITLE
Add feedback twig tags with the Auth feedback

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -13,6 +13,7 @@ debug: true
 #
 #registration:
 #    enabled: true
+#    auto: false
 
 ## Notification email addresses ###############################################
 #
@@ -22,9 +23,30 @@ debug: true
 #notification:
 #    name: Site Admin              # Display name used as the sender name
 #    email: no-reply@example.com   # Email address as the sender address
+#    format: mixed                 # html, plain or mixed
+
+## redirects ##################################################################
+#
+#redirects
+#    login: null                   # Redirect after succesfull login
+#    logout: null                  # Redirect after logout
+
+## urls #######################################################################
+#
+#urls:
+#    authenticate: authentication  # The {authenticate} mentioned in the docs
+#                                  # for paths like /{authenticate}/login
+#    auth: auth                    # The {auth} mentioned in the docs for
+#                                  # for paths like /{auth}/profile
 
 ## Access Control #############################################################
 #
+#roles:
+#    admin: root
+#    auth:
+#        admin: Administrator
+#        participant: Participant
+#    register: participant
 roles:
     auth:
         admin: Administrator
@@ -46,6 +68,49 @@ providers:
 
 ## Form Configuration #########################################################
 #
-#forms:
+# Default values for the forms are set to the following templates and labels
+#
 #    templates:
+#        profile:
+#            parent: '@Auth/profile/_profile.twig'
+#            edit: '@Auth/profile/edit.twig'
+#            register: '@Auth/profile/register.twig'
+#            verify: '@Auth/profile/verify.twig'
+#        authentication:
+#            parent: '@Auth/authentication/_authentication.twig'
+#            associate: '@Auth/authentication/associate.twig'
+#            login: '@Auth/authentication/login.twig'
+#            logout: '@Auth/authentication/logout.twig'
+#            recovery: '@Auth/authentication/recovery.twig'
+#        error:
+#            parent: '@Auth/error/_error.twig'
+#            error: '@Auth/error/error.twig'
+#        feedback:
+#            feedback: '@Auth/feedback/feedback.twig'
+#        recovery:
+#            subject: '@Auth/authentication/recovery/subject.twig'
+#            html: '@Auth/authentication/recovery/html.twig'
+#            text: '@Auth/authentication/recovery/text.twig'
+#        verification:
+#            subject: '@Auth/profile/registration/subject.twig'
+#            html: '@Auth/profile/registration/html.twig'
+#            text: '@Auth/profile/registration/text.twig'
+#    labels:
+#        login: 'Login'
+#        logout: 'Logout'
+#        displayname: 'Public Name'
+#        email: 'Email Address'
+#        password_first: 'Password'
+#        password_second: 'Repeat Password'
+#        profile_save: 'Save & Continue'
+#    placeholders:
+#        displayname: 'The name you would like to display publicly…'
+#        email: 'Your email address…'
+#        password_first: 'Enter your password…'
+#        password_second: 'Repeat the above password…'
+#    addons:
+#        zocial: false
 
+## Firewalls ##################################################################
+#
+#firewalls: null

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -30,6 +30,10 @@ debug: true
 #redirects
 #    login: null                   # Redirect after succesfull login
 #    logout: null                  # Redirect after logout
+#    register: null                # Redirect after registration
+#    reset: null                   # Redirect after password reset
+#    verify: null                  # Redirect after verification
+#    delete: null                  # Redirect after account deletion
 
 ## urls #######################################################################
 #

--- a/src/AccessControl/Session.php
+++ b/src/AccessControl/Session.php
@@ -4,6 +4,7 @@ namespace Bolt\Extension\BoltAuth\Auth\AccessControl;
 
 use Bolt\Extension\BoltAuth\Auth\Exception;
 use Bolt\Extension\BoltAuth\Auth\Storage;
+use Bolt\Extension\BoltAuth\Auth\Feedback;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Token\AccessToken;
 use Ramsey\Uuid\Uuid;
@@ -497,6 +498,17 @@ class Session
         $attributes[$attribute] = $value;
 
         $this->session->set(self::SESSION_ATTRIBUTES, $attributes);
+    }
+
+
+    /**
+     * Return feedback if it exists in the session flashbag
+     *
+     * @return Feedback
+     */
+    public function getFeedback()
+    {
+        return $this->session->getBag('auth.feedback');
     }
 
     /**

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -79,6 +79,7 @@ class Config
         $this->redirectLogout = $config['redirects']['logout'];
         $this->redirectRegister = $config['redirects']['register'];
         $this->redirectVerify = $config['redirects']['verify'];
+        $this->redirectReset = $config['redirects']['reset'];
         $this->redirectDelete = $config['redirects']['delete'];
 
         $this->forms = new Forms($config['forms']);

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -42,6 +42,14 @@ class Config
     protected $redirectLogin;
     /** @var string */
     protected $redirectLogout;
+    /** @var string */
+    protected $redirectRegister;
+    /** @var string */
+    protected $redirectReset;
+    /** @var string */
+    protected $redirectVerify;
+    /** @var string */
+    protected $redirectDelete;
     /** @var  Forms */
     protected $forms;
     /** @var array */
@@ -69,6 +77,9 @@ class Config
         $this->notificationEmailFormat = $config['notification']['format'];
         $this->redirectLogin = $config['redirects']['login'];
         $this->redirectLogout = $config['redirects']['logout'];
+        $this->redirectRegister = $config['redirects']['register'];
+        $this->redirectVerify = $config['redirects']['verify'];
+        $this->redirectDelete = $config['redirects']['delete'];
 
         $this->forms = new Forms($config['forms']);
 
@@ -198,6 +209,87 @@ class Config
     public function setRedirectLogout($redirectLogout)
     {
         $this->redirectLogout = $redirectLogout;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedirectRegister()
+    {
+        return $this->redirectRegister;
+    }
+
+    /**
+     * @param string $redirectRegister
+     *
+     * @return Config
+     */
+    public function setRedirectRegister($redirectRegister)
+    {
+        $this->redirectRegister = $redirectRegister;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedirectReset()
+    {
+        return $this->redirectReset;
+    }
+
+    /**
+     * @param string $redirectReset
+     *
+     * @return Config
+     */
+    public function setRedirectReset($redirectReset)
+    {
+        $this->redirectReset = $redirectReset;
+
+        return $this;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getRedirectVerify()
+    {
+        return $this->redirectVerify;
+    }
+
+    /**
+     * @param string $redirectVerify
+     *
+     * @return Config
+     */
+    public function setRedirectVerify($redirectVerify)
+    {
+        $this->redirectVerify = $redirectVerify;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedirectDelete()
+    {
+        return $this->redirectDelete;
+    }
+
+    /**
+     * @param string $redirectDelete
+     *
+     * @return Config
+     */
+    public function setRedirectDelete($redirectDelete)
+    {
+        $this->redirectDelete = $redirectDelete;
 
         return $this;
     }
@@ -590,8 +682,11 @@ class Config
                 'format' => 'mixed',
             ],
             'redirects'    => [
-                'login'  => null,
-                'logout' => null,
+                'login'    => null,
+                'logout'   => null,
+                'register' => null,
+                'verify'   => null,
+                'delete'   => null,
             ],
             'roles'        => [
                 'admin'  => [

--- a/src/Controller/Auth.php
+++ b/src/Controller/Auth.php
@@ -199,6 +199,11 @@ class Auth extends AbstractController
                     $session->removeAttribute(Session::SESSION_ATTRIBUTE_OAUTH_DATA);
                 }
 
+                // if redirect:register is set in extension configuration redirect there
+                if ($this->getAuthConfig()->getRedirectRegister() != null) {
+                    return new RedirectResponse($this->getAuthConfig()->getRedirectRegister());
+                }
+
                 // Redirect to our profile page.
                 $response = new RedirectResponse($app['url_generator']->generate('authProfileEdit'));
 
@@ -258,6 +263,11 @@ class Auth extends AbstractController
             $event = new AuthProfileEvent($verification->getAccount());
             $app['dispatcher']->dispatch(AuthEvents::AUTH_PROFILE_VERIFY, $event);
             $session->set($sessionKey, $verification);
+
+            // if redirect:verify is set in extension configuration redirect there
+            if ($this->getAuthConfig()->getRedirectVerify() != null) {
+                return new RedirectResponse($this->getAuthConfig()->getRedirectVerify());
+            }
 
             return new RedirectResponse($app['url_generator']->generate('authProfileVerify'));
         }

--- a/src/Controller/Authentication.php
+++ b/src/Controller/Authentication.php
@@ -316,6 +316,11 @@ class Authentication extends AbstractController
             $builder = $this->resetPasswordRequest($app, $request, $context, $response);
         }
 
+        // if stage is complete and redirect:reset is set in extension configuration redirect there
+        if ($context->get('stage') == 'submitted' && $this->getAuthConfig()->getRedirectReset() != null) {
+            return new RedirectResponse($this->getAuthConfig()->getRedirectReset());
+        }
+
         $template = $this->getAuthConfig()->getTemplate('authentication', 'recovery');
         $html = $this->getAuthFormsManager()->renderForms($builder, $app['twig'], $template, $context->all());
         $response->setContent(new \Twig_Markup($html, 'UTF-8'));

--- a/src/Event/AuthEvents.php
+++ b/src/Event/AuthEvents.php
@@ -26,6 +26,7 @@ class AuthEvents
     const AUTH_PROFILE_REGISTER = 'auth.profile.register';
     const AUTH_PROFILE_RESET = 'auth.profile.reset';
     const AUTH_PROFILE_VERIFY = 'auth.profile.verify';
+    const AUTH_PROFILE_DELETE = 'auth.profile.delete';
     const AUTH_ROLE = 'auth.role';
     const AUTH_NOTIFICATION_PRE_SEND = 'auth.notification.pre_send';
     const AUTH_NOTIFICATION_FAILURE = 'auth.notification.failure';

--- a/src/Twig/Extension/AuthExtension.php
+++ b/src/Twig/Extension/AuthExtension.php
@@ -41,6 +41,7 @@ class AuthExtension extends Extension
             new SimpleFunction('auth_link_auth_login',       [AuthRuntime::class, 'getLinkLogin'],    $safe),
             new SimpleFunction('auth_link_auth_logout',      [AuthRuntime::class, 'getLinkLogout'],   $safe),
             new SimpleFunction('auth_link_auth_reset',       [AuthRuntime::class, 'getLinkReset'],    $safe),
+            new SimpleFunction('auth_link_profile_view',     [AuthRuntime::class, 'getLinkView'],     $safe),
             new SimpleFunction('auth_link_profile_edit',     [AuthRuntime::class, 'getLinkEdit'],     $safe),
             new SimpleFunction('auth_link_profile_register', [AuthRuntime::class, 'getLinkRegister'], $safe),
             new SimpleFunction('auth_profile_edit',          [AuthRuntime::class, 'renderEdit'],      $safe + $env),

--- a/src/Twig/Extension/AuthExtension.php
+++ b/src/Twig/Extension/AuthExtension.php
@@ -34,6 +34,8 @@ class AuthExtension extends Extension
             new SimpleFunction('auth_has_role',              [AuthRuntime::class, 'hasRole'],         $safe),
             new SimpleFunction('auth_providers',             [AuthRuntime::class, 'getProviders'],    $safe),
             new SimpleFunction('auth_lastseen',              [AuthRuntime::class, 'getProvidersLastSeen'],    $safe),
+            new SimpleFunction('auth_feedback',              [AuthRuntime::class, 'getFeedback'],     $safe),
+            new SimpleFunction('auth_render_feedback',       [AuthRuntime::class, 'renderFeedback'],  $safe + $env),
             new SimpleFunction('auth_auth_switcher',         [AuthRuntime::class, 'renderSwitcher'],  $safe + $env),
             new SimpleFunction('auth_auth_associate',        [AuthRuntime::class, 'renderAssociate'], $safe + $env),
             new SimpleFunction('auth_auth_login',            [AuthRuntime::class, 'renderLogin'],     $safe + $env),

--- a/src/Twig/Extension/AuthRuntime.php
+++ b/src/Twig/Extension/AuthRuntime.php
@@ -385,6 +385,18 @@ class AuthRuntime extends TwigExtension
     }
 
     /**
+     * Get the URL for profile viewing.
+     *
+     * @param int $format
+     *
+     * @return string
+     */
+    public function getLinkView($format = UrlGeneratorInterface::RELATIVE_PATH)
+    {
+        return $this->generator->generate('authProfileView', [], $format);
+    }
+
+    /**
      * Get the URL for profile editing.
      *
      * @param int $format

--- a/src/Twig/Extension/AuthRuntime.php
+++ b/src/Twig/Extension/AuthRuntime.php
@@ -3,6 +3,7 @@
 namespace Bolt\Extension\BoltAuth\Auth\Twig\Extension;
 
 use Bolt\Extension\BoltAuth\Auth\AccessControl;
+use Bolt\Extension\BoltAuth\Auth\AccessControl\Session;
 use Bolt\Extension\BoltAuth\Auth\Config\Config;
 use Bolt\Extension\BoltAuth\Auth\Form;
 use Bolt\Extension\BoltAuth\Auth\Storage;
@@ -419,4 +420,41 @@ class AuthRuntime extends TwigExtension
     {
         return $this->generator->generate('authProfileRegister', [], $format);
     }
+
+
+    /**
+     * Get the all current feedback for Auth to use in twig.
+     *
+     * @param int $format
+     *
+     * @return string
+     */
+    public function getFeedback($peek = true)
+    {
+        if($peek) {
+            return $this->session->getFeedback()->peek();
+        } else {
+            return $this->session->getFeedback()->get();
+        }
+    }
+
+    /**
+     * Display all current feedback for Auth.
+     *
+     * @param TwigEnvironment $twigEnvironment
+     * @param string          $template
+     *
+     * @return TwigMarkup
+     */
+    public function renderFeedback(TwigEnvironment $twigEnvironment, $template = null)
+    {
+        $context = ['feedback' => $this->session->getFeedback()];
+        $template = $template ?: $this->config->getTemplate('feedback', 'feedback');
+        // use the profile view form because it should be read only and harmless
+        $form = $this->formManager->getFormProfileView(new Request());
+        $html = $this->formManager->renderForms($form, $twigEnvironment, $template, $context);
+
+        return new TwigMarkup($html, 'UTF-8');
+    }
+
 }

--- a/templates/authentication/_authentication.twig
+++ b/templates/authentication/_authentication.twig
@@ -32,7 +32,7 @@
 {% extends "partials/_master.twig" %}
 
 {% block main %}
-
+<div class="boltform">
     {% block login %}
     {% endblock login %}
 
@@ -41,5 +41,5 @@
 
     {% block recovery %}
     {% endblock recovery %}
-
+</div>
 {% endblock main %}

--- a/templates/authentication/_authentication.twig
+++ b/templates/authentication/_authentication.twig
@@ -3,9 +3,15 @@
  #
  ### Installing in your theme:
  # Create a Twig template file in your theme directory, that inherits your page
- # layout and then add the following block:
- #     {% block login %}
- #     {% endblock login %}
+ # layout and then add the following blocks:
+ #   {% block login %}
+ #   {% endblock login %}
+ #
+ #   {% block logout %}
+ #   {% endblock logout %}
+ #
+ #   {% block recovery %}
+ #   {% endblock recovery %}
  #
  ### Configuring Auth to use your template parent:
  #
@@ -14,14 +20,14 @@
  #   parent:
  #
  # For example if you have a theme directory 'koala' and you create the directory
- # themes/koala/extensions/clientlogin/ you can then put what templates files
+ # themes/koala/auth/ you can then put what templates files
  # you need there.
  #
- # In app/config/extensions/auth.bolt.yml set the following to override
+ # In app/config/extensions/auth.boltauth.yml set the following to override
  #
  #     templates:
  #       authentication:
- #         parent: extensions/auth/login.twig
+ #         parent: auth/_authentication.twig
  #}
 {% extends "partials/_master.twig" %}
 

--- a/templates/authentication/associate.twig
+++ b/templates/authentication/associate.twig
@@ -13,18 +13,15 @@
 {% block login %}
     {{ include(templates.feedback) }}
 
+    <div class="login login-associate">
 
-    <div class="login">
-        <div class="row auth-login">
+        {{ _self.oauth_login(form_associate, providers) }}
 
-            {{ _self.oauth_login(form_associate, providers) }}
-
-        </div>
     </div>
 {% endblock login %}
 
 {% macro oauth_login(form_associate, providers) %}
-    <div class="small-6 columns auth-login-password">
+    <div class="login-associate-provider">
         {{ form_start(form_associate) }}
 
         {% for provider in providers|keys %}

--- a/templates/authentication/login.twig
+++ b/templates/authentication/login.twig
@@ -21,6 +21,8 @@
         {% endif %}
 
         {{ _self.oauth_login(form_login_oauth, providers) }}
+
+        <a class="button" href="{{ auth_link_auth_reset() }}">Reset password</a>
     </div>
 {% endblock login %}
 

--- a/templates/authentication/login.twig
+++ b/templates/authentication/login.twig
@@ -15,19 +15,17 @@
     {{ include(templates.feedback) }}
 
     <div class="login">
-        <div class="row auth-login">
 
-            {% if providers.local is defined %}
-                {{ _self.password_login(form_login_password) }}
-            {% endif %}
+        {% if providers.local is defined %}
+            {{ _self.password_login(form_login_password) }}
+        {% endif %}
 
-            {{ _self.oauth_login(form_login_oauth, providers) }}
-        </div>
+        {{ _self.oauth_login(form_login_oauth, providers) }}
     </div>
 {% endblock login %}
 
 {% macro password_login(form_login_password) %}
-    <div class="small-6 columns auth-login-password">
+    <div class="login-password">
         {{ form_start(form_login_password) }}
 
         {{ form_row(form_login_password.email) }}
@@ -41,7 +39,7 @@
 
 
 {% macro oauth_login(form_login_oauth, providers) %}
-    <div class="small-6 columns auth-login-password">
+    <div class="login-oauth">
         {{ form_start(form_login_oauth) }}
 
         {% for provider in providers|keys %}

--- a/templates/authentication/logout.twig
+++ b/templates/authentication/logout.twig
@@ -14,12 +14,10 @@
     {{ include(templates.feedback) }}
 
     <div class="logout">
-        <div class="row auth-logout">
-            {{ form_start(form_logout) }}
+        {{ form_start(form_logout) }}
 
-            {{ form_row(form_logout.logout) }}
+        {{ form_row(form_logout.logout) }}
 
-            {{ form_end(form_logout) }}
-        </div>
+        {{ form_end(form_logout) }}
     </div>
 {% endblock logout %}

--- a/templates/authentication/recovery.twig
+++ b/templates/authentication/recovery.twig
@@ -19,22 +19,20 @@
 {% block recovery %}
     {{ include(templates.feedback) }}
 
-    <div class="logout">
-        <div class="row auth-recovery">
-            {%  if stage == 'email' %}
-                {{ _self.recovery_start(form_profile_recovery_request) }}
-            {% elseif stage == 'password' %}
-                {{ _self.recovery_finish(form_profile_recovery_submit) }}
-            {% elseif stage == 'submitted' %}
-                <p>{{ __('An email has been sent to') }} {{ email }}. {{ __('Please follow the instructions to complete the process.') }}</p>
-            {% elseif stage == 'reset' %}
-                <p>{{ __('Password reset was successful!') }}</p>
-                <p><a href="{{ link }}">{{ __('Click here to go to the login page…') }}</a></p>
-            {% else %}
-                <p>{{ __('Invalid request!') }}</p>
-            {% endif %}
+    <div class="login login-recovery">
+        {%  if stage == 'email' %}
+            {{ _self.recovery_start(form_profile_recovery_request) }}
+        {% elseif stage == 'password' %}
+            {{ _self.recovery_finish(form_profile_recovery_submit) }}
+        {% elseif stage == 'submitted' %}
+            <p>{{ __('An email has been sent to') }} {{ email }}. {{ __('Please follow the instructions to complete the process.') }}</p>
+        {% elseif stage == 'reset' %}
+            <p>{{ __('Password reset was successful!') }}</p>
+            <p><a href="{{ link }}">{{ __('Click here to go to the login page…') }}</a></p>
+        {% else %}
+            <p>{{ __('Invalid request!') }}</p>
+        {% endif %}
 
-        </div>
     </div>
 
 {% endblock recovery %}

--- a/templates/authentication/recovery.twig
+++ b/templates/authentication/recovery.twig
@@ -47,6 +47,8 @@
     {{ form_row(form_profile_recovery.submit, { 'label': __('Submit »'), 'attr': { 'class': 'button btn btn-default' }}) }}
 
     {{ form_end(form_profile_recovery) }}
+
+    <a class="button" href="{{ auth_link_auth_login() }}">Back to login</a>
 {% endmacro %}
 
 {% macro recovery_finish(form_profile_recovery) %}
@@ -60,4 +62,6 @@
     {{ form_row(form_profile_recovery.submit, { 'label': __('Continue »'), 'attr': { 'class': 'button btn btn-default' }}) }}
 
     {{ form_end(form_profile_recovery) }}
+
+    <a class="button" href="{{ auth_link_auth_login() }}">Back to login</a>
 {% endmacro %}

--- a/templates/feedback/feedback.twig
+++ b/templates/feedback/feedback.twig
@@ -12,44 +12,40 @@
 
 {% set feedback = feedback.get|default(null) %}
 {% if feedback %}
-    <div class="row">
-        <div class="small-12 columns">
 
-            <div class="panel auth-feedback">
-                {% if feedback.debug|default(null) %}
-                    <div class="auth-messages-debug">
-                        <h5>{{ __('Debug Messages') }}:</h5>
-                        <ul class="auth-feedback-messages">
-                            {% for message in feedback.debug %}
-                                <li>{{ message }}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                {% endif %}
-
-                {% if feedback.error|default(null) %}
-                    <div class="auth-messages-error">
-                        <h5>{{ __('Error Messages') }}:</h5>
-                        <ul class="auth-feedback-messages">
-                            {% for message in feedback.error %}
-                                <li>{{ message }}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                {% endif %}
-
-                {% if feedback.info|default(null) %}
-                    <div class="auth-messages-info">
-                        <h5>{{ __('Informational Messages') }}:</h5>
-                        <ul class="auth-feedback-messages">
-                            {% for info in feedback.info %}
-                                <li>{{ info }}</li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                {% endif %}
-
-            </div>
+<div class="auth-feedback">
+    {% if feedback.debug|default(null) %}
+        <div class="messages debug">
+            <h5>{{ __('Debug Messages') }}:</h5>
+            <ul>
+                {% for message in feedback.debug %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+            </ul>
         </div>
-    </div>
+    {% endif %}
+
+    {% if feedback.error|default(null) %}
+        <div class="messages error">
+            <h5>{{ __('Error Messages') }}:</h5>
+            <ul>
+                {% for message in feedback.error %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    {% if feedback.info|default(null) %}
+        <div class="messages info">
+            <h5>{{ __('Informational Messages') }}:</h5>
+            <ul>
+                {% for info in feedback.info %}
+                    <li>{{ info }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+</div>
 {% endif %}

--- a/templates/profile/_profile.twig
+++ b/templates/profile/_profile.twig
@@ -1,10 +1,28 @@
 {#
- # NOTE:
+ # This is just a default base, and example only.
  #
- # When overriding this template, Auth only needs the `auth` block:
+ ### Installing in your theme:
+ # Create a Twig template file in your theme directory, that inherits your page
+ # layout and then add the following blocks:
  #
  #   {% block auth %}
  #   {% endblock auth %}
+ #
+ ### Configuring Auth to use your template parent:
+ #
+ # Next step is to set the template key to the relative path to template file.
+ # authentication:
+ #   parent:
+ #
+ # For example if you have a theme directory 'koala' and you create the directory
+ # themes/koala/auth/ you can then put what templates files
+ # you need there.
+ #
+ # In app/config/extensions/auth.boltauth.yml set the following to override
+ #
+ #     templates:
+ #       profile:
+ #         parent: auth/_profile.twig
  #}
 
 {% extends "partials/_master.twig" %}

--- a/templates/profile/_profile.twig
+++ b/templates/profile/_profile.twig
@@ -34,6 +34,7 @@
 
     <ul>
         <li><a href="{{ auth_link_profile_edit() }}">Edit profile</a></li>
+        <li><a href="{{ auth_link_profile_view() }}">View profile</a></li>
         <li><a href="{{ auth_link_auth_logout() }}">Logout</a></li>
     </ul>
 </div>

--- a/templates/profile/_profile.twig
+++ b/templates/profile/_profile.twig
@@ -31,5 +31,10 @@
 <div class="boltform">
     {% block auth %}
     {% endblock auth %}
+
+    <ul>
+        <li><a href="{{ auth_link_profile_edit() }}">Edit profile</a></li>
+        <li><a href="{{ auth_link_auth_logout() }}">Logout</a></li>
+    </ul>
 </div>
 {% endblock main %}

--- a/templates/profile/_profile.twig
+++ b/templates/profile/_profile.twig
@@ -28,8 +28,8 @@
 {% extends "partials/_master.twig" %}
 
 {% block main %}
-
+<div class="boltform">
     {% block auth %}
     {% endblock auth %}
-
+</div>
 {% endblock main %}

--- a/templates/profile/edit.twig
+++ b/templates/profile/edit.twig
@@ -35,22 +35,25 @@
 
         <ul>
             {%- for provider in auth_providers() %}
-                <li><i class="fa fa-{{ provider }}">  {{ provider|title }}</i></li>
+                <li><i class="fa fa-{{ provider }}">{{ provider|title }}</i></li>
             {% endfor -%}
         </ul>
     </div>
 
-    <di class="profile profile-add-social">
+    <div class="profile profile-add-social">
         {% for provider in providers|keys %}
-            {% if provider != 'local' and provider not in auth_providers() %}
-                {% if loop.first %}<h5>{{ __('Add Social Media Account') }}</h5>{% endif %}
+            {% if loop.first %}
+                <h5>{{ __('Add Social Media Account') }}</h5>
                 {{ form_start(form_associate) }}
-                    {{ form_row(form_associate[provider]) }}
+            {% endif %}
+            {% if provider != 'local' and provider not in auth_providers() %}
+                {{ form_row(form_associate[provider], { 'attr': { 'class': 'button btn btn-default' }}) }}
+            {% else %}
+                <div><p>{{ provider|capitalize }} is already connected.</p></div>
+            {% endif %}
+            {% if loop.last %}
                 {{ form_end(form_associate) }}
             {% endif %}
         {% endfor %}
-
-        {{ form_end(form_associate) }}
     </div>
-
 {% endblock %}

--- a/templates/profile/edit.twig
+++ b/templates/profile/edit.twig
@@ -12,50 +12,45 @@
 {% extends twigparent %}
 
 {% block auth %}
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-    <div class="row">
-        <h4>{{ __('Edit Profile') }}</h4>
-    </div>
+    <h4>{{ __('Edit Profile') }}</h4>
 
     {{ include(templates.feedback) }}
 
-    <div class="row profile">
 
-        <div class="small-12 columns">
+    <div class="profile profile-edit">
 
-            {{ form_start(form_profile_edit) }}
-                {{ form_errors(form_profile_edit) }}
-                {% for name, row in form_profile_edit if name not in ['submit', 'password'] %}
-                    <div class="auth_{{ row.vars.name }}">{{ form_row(row) }}</div>
-                {% endfor %}
-                {{ form_row(form_profile_edit.password) }}
-                {{ form_row(form_profile_edit.submit, {'attr': {'class': 'button btn btn-default'}}) }}
-            {{ form_end(form_profile_edit) }}
-
-        </div>
-
-        <div class="small-12 columns">
-            <h5>{{ __('Registered Social Media Accounts') }}</h5>
-
-            <ul>
-                {%- for provider in auth_providers() %}
-                    <li><i class="fa fa-{{ provider }}">  {{ provider|title }}</i></li>
-                {% endfor -%}
-            </ul>
-        </div>
-
-        <div class="small-12 columns">
-            {% for provider in providers|keys %}
-                {% if provider != 'local' and provider not in auth_providers() %}
-                    {% if loop.first %}<h5>{{ __('Add Social Media Account') }}</h5>{% endif %}
-                    {{ form_start(form_associate) }}
-                        {{ form_row(form_associate[provider]) }}
-                    {{ form_end(form_associate) }}
-                {% endif %}
+        {{ form_start(form_profile_edit) }}
+            {{ form_errors(form_profile_edit) }}
+            {% for name, row in form_profile_edit if name not in ['submit', 'password'] %}
+                <div class="auth_{{ row.vars.name }}">{{ form_row(row) }}</div>
             {% endfor %}
-
-            {{ form_end(form_associate) }}
-        </div>
+            {{ form_row(form_profile_edit.password) }}
+            {{ form_row(form_profile_edit.submit, {'attr': {'class': 'button btn btn-default'}}) }}
+        {{ form_end(form_profile_edit) }}
 
     </div>
+
+    <div class="profile profile-registered-social">
+        <h5>{{ __('Registered Social Media Accounts') }}</h5>
+
+        <ul>
+            {%- for provider in auth_providers() %}
+                <li><i class="fa fa-{{ provider }}">  {{ provider|title }}</i></li>
+            {% endfor -%}
+        </ul>
+    </div>
+
+    <di class="profile profile-add-social">
+        {% for provider in providers|keys %}
+            {% if provider != 'local' and provider not in auth_providers() %}
+                {% if loop.first %}<h5>{{ __('Add Social Media Account') }}</h5>{% endif %}
+                {{ form_start(form_associate) }}
+                    {{ form_row(form_associate[provider]) }}
+                {{ form_end(form_associate) }}
+            {% endif %}
+        {% endfor %}
+
+        {{ form_end(form_associate) }}
+    </div>
+
 {% endblock %}

--- a/templates/profile/register.twig
+++ b/templates/profile/register.twig
@@ -15,36 +15,32 @@
 {% extends twigparent %}
 
 {% block auth %}
-    <div class="row">
-        <h4>{{ __('New Auth') }}</h4>
-    </div>
+    <h4>{{ __('New Auth') }}</h4>
 
     {{ include(templates.feedback) }}
 
-    <div class="row register">
 
-        <div class="small-12 columns">
+    <div class="profile profile-register">
 
-            {{ form_start(form_profile_register) }}
+        {{ form_start(form_profile_register) }}
 
-            {{ form_errors(form_profile_register) }}
+        {{ form_errors(form_profile_register) }}
 
-            {{ form_row(form_profile_register.displayname, { 'value': auth.name|default() } ) }}
-            {{ form_row(form_profile_register.email, { 'value': auth.email|default() } ) }}
+        {{ form_row(form_profile_register.displayname, { 'value': auth.name|default() } ) }}
+        {{ form_row(form_profile_register.email, { 'value': auth.email|default() } ) }}
 
-            {% if transitional %}
-                {% do form_profile_register.password.setRendered %}
-            {% else %}
-                {{ form_widget(form_profile_register.password.first, { 'attr': {'autocomplete': 'new-password'}}) }}
-                {{ form_widget(form_profile_register.password.second, { 'attr': {'autocomplete': 'new-password'}}) }}
-            {% endif %}
+        {% if transitional %}
+            {% do form_profile_register.password.setRendered %}
+        {% else %}
+            {{ form_widget(form_profile_register.password.first, { 'attr': {'autocomplete': 'new-password'}}) }}
+            {{ form_widget(form_profile_register.password.second, { 'attr': {'autocomplete': 'new-password'}}) }}
+        {% endif %}
 
-                <br>
-            {{ form_row(form_profile_register.submit, { 'attr': { 'class': 'button btn btn-default' }}) }}
+            <br>
+        {{ form_row(form_profile_register.submit, { 'attr': { 'class': 'button btn btn-default' }}) }}
 
-            {{ form_end(form_profile_register) }}
-
-        </div>
+        {{ form_end(form_profile_register) }}
 
     </div>
+
 {% endblock %}

--- a/templates/profile/register.twig
+++ b/templates/profile/register.twig
@@ -32,8 +32,7 @@
         {% if transitional %}
             {% do form_profile_register.password.setRendered %}
         {% else %}
-            {{ form_widget(form_profile_register.password.first, { 'attr': {'autocomplete': 'new-password'}}) }}
-            {{ form_widget(form_profile_register.password.second, { 'attr': {'autocomplete': 'new-password'}}) }}
+            {{ form_row(form_profile_register.password) }}
         {% endif %}
 
             <br>

--- a/templates/profile/verify.twig
+++ b/templates/profile/verify.twig
@@ -13,23 +13,18 @@
 {% extends twigparent %}
 
 {% block auth %}
-    <div class="row">
-        <h4>{{ __('Account Verification') }}</h4>
-    </div>
+    <h4>{{ __('Account Verification') }}</h4>
 
     {{ include(templates.feedback) }}
 
-    <div class="row verify">
+    <div class="profile profile-verify">
 
-        <div class="small-12 columns">
+        {% if success %}
+            <p>{{ __('Your account has been successfully verified!') }}</p>
+        {% else %}
+            <p>{{ __('Account verification code is invalid!') }}</p>
+        {% endif %}
 
-            {% if success %}
-                <p>{{ __('Your account has been successfully verified!') }}</p>
-            {% else %}
-                <p>{{ __('Account verification code is invalid!') }}</p>
-            {% endif %}
-
-        </div>
 
     </div>
 {% endblock %}

--- a/templates/profile/view.twig
+++ b/templates/profile/view.twig
@@ -24,9 +24,11 @@
 
     <div class="profile profile-view">
 
-        <div class="small-3 columns">
+        {% if auth.avatar %}
+        <div class="profile-image">
             <img alt="{{ auth.displayname }}" src="{{ auth.avatar }}">
         </div>
+        {% endif %}
 
         {{ form_start(form_profile_view) }}
 

--- a/templates/profile/view.twig
+++ b/templates/profile/view.twig
@@ -18,31 +18,26 @@
 {% extends twigparent %}
 
 {% block auth %}
-
-    <div class="row">
-        <h4>{{ __('Auth Profile') }} — {{ auth.displayname }}</h4>
-    </div>
+    <h4>{{ __('Auth Profile') }} — {{ auth.displayname }}</h4>
 
     {{ include(templates.feedback) }}
 
-    <div class="row profile">
+    <div class="profile profile-view">
 
         <div class="small-3 columns">
             <img alt="{{ auth.displayname }}" src="{{ auth.avatar }}">
         </div>
 
-        <div class="small-9 columns">
-            {{ form_start(form_profile_view) }}
+        {{ form_start(form_profile_view) }}
 
-            {{ form_row(form_profile_view.displayname) }}
-            {{ form_row(form_profile_view.email) }}
+        {{ form_row(form_profile_view.displayname) }}
+        {{ form_row(form_profile_view.email) }}
 
-            {% do form_profile_view.password.setRendered %}
-            {% do form_profile_view.submit.setRendered %}
+        {% do form_profile_view.password.setRendered %}
+        {% do form_profile_view.submit.setRendered %}
 
 
-            {{ form_end(form_profile_view) }}
-        </div>
+        {{ form_end(form_profile_view) }}
 
     </div>
 {% endblock %}


### PR DESCRIPTION
This is an approach to add feedback to https://github.com/BoltAuth/Auth/issues/44
This adds two twig tags that can be used globally.

`{{ auth_render_feedback() }}`

`{% set feedback = auth_feedback() %}`

This also applies to https://github.com/BoltAuth/Auth/issues/23