### PR TITLE
Set unsuccessful actions to `error` instead of `info`

### DIFF
--- a/src/Controller/Auth.php
+++ b/src/Controller/Auth.php
@@ -131,7 +131,7 @@ class Auth extends AbstractController
         $authSession = $this->getAuthSession()->getAuthorisation();
         if ($authSession === null) {
             $app['session']->set(Authentication::FINAL_REDIRECT_KEY, $request->getUri());
-            $this->getAuthFeedback()->info('Login required to edit your profile');
+            $this->getAuthFeedback()->error('Login required to edit your profile');
 
             return new RedirectResponse($app['url_generator']->generate('authenticationLogin'));
         }
@@ -323,7 +323,7 @@ class Auth extends AbstractController
             $authSession = $this->getAuthSession()->getAuthorisation();
             if ($authSession === null) {
                 $app['session']->set(Authentication::FINAL_REDIRECT_KEY, $request->getUri());
-                $this->getAuthFeedback()->info('Login required to view your profile');
+                $this->getAuthFeedback()->error('Login required to view your profile');
 
                 return new RedirectResponse($app['url_generator']->generate('authenticationLogin'));
             }

--- a/src/Controller/Authentication.php
+++ b/src/Controller/Authentication.php
@@ -210,7 +210,7 @@ class Authentication extends AbstractController
                 return $response;
             }
 
-            $this->getAuthFeedback()->info('Login details are incorrect.');
+            $this->getAuthFeedback()->error('Login details are incorrect.');
         }
         $template = $config->getTemplate('authentication', 'login');
         $html = $this->getAuthFormsManager()->renderForms($builder, $app['twig'], $template);

--- a/src/Feedback.php
+++ b/src/Feedback.php
@@ -107,7 +107,7 @@ class Feedback implements SessionBagInterface
     public function set($state, $message)
     {
         if (empty($state) || !in_array($state, ['debug', 'error', 'info'])) {
-            throw new \InvalidArgumentException("Feedback state can only be 'error', 'message', or 'debug'.");
+            throw new \InvalidArgumentException("Feedback state can only be 'error', 'info', or 'debug'.");
         }
 
         // Don't log debug messages when not debugging

--- a/src/Oauth2/Handler/Local.php
+++ b/src/Oauth2/Handler/Local.php
@@ -49,13 +49,13 @@ class Local extends AbstractHandler
 
         $oauth = $this->records->getOauthByGuid($account->getGuid());
         if (!$oauth instanceof Entity\Oauth) {
-            $this->feedback->info('Registration is required.');
+            $this->feedback->error('Registration is required.');
 
             return new RedirectResponse($this->urlGenerator->generate('authProfileRegister'));
         }
 
         if (!$oauth->getEnabled()) {
-            $this->feedback->info('Account disabled.');
+            $this->feedback->error('Account disabled.');
 
             return new RedirectResponse($this->urlGenerator->generate('authenticationLogin'));
         }


### PR DESCRIPTION
There's only `debug`, `info` and `error` for feedback. Since everything is info, there is no way to distinguish between the two in the front-end.

Not sure why this was the case though.